### PR TITLE
Add targets for only building AppClips and Widgets

### DIFF
--- a/MAUI.Native.Embedded.nuget/build/MAUI.Native.Embedded.ios.appclips.targets
+++ b/MAUI.Native.Embedded.nuget/build/MAUI.Native.Embedded.ios.appclips.targets
@@ -85,4 +85,6 @@
     <Error Condition="'$(ExitCode)' != '' AND '$(ExitCode)' != '0'" Code="1013" Text="AppClips application identifier does not mathc this 'ApplicationId': $(ApplicationId)" />
   </Target>
 
+  <Target Name="BuildAppClips" DependsOnTargets="ProcessAppClips" />
+
 </Project>

--- a/MAUI.Native.Embedded.nuget/build/MAUI.Native.Embedded.ios.widgets.targets
+++ b/MAUI.Native.Embedded.nuget/build/MAUI.Native.Embedded.ios.widgets.targets
@@ -88,4 +88,6 @@
   </Target>
   -->
 
+  <Target Name="BuildWidgets" DependsOnTargets="ProcessWidgets" />
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ When e.g. adding AppClips, you might want to only build and embed the native pro
 ### Hint: Custom Xcode project version
 If your Xcode project uses a custom way of storing versions, you can make an custom update here.
 
-All you need to do is to add this target to your project (.csproj)
+All you need to do is to add this target to your project (`.csproj`)
 ```
 <Target Name="CustomXcodeUpdateVersion" AfterTargets="_UpdateXcodeProjectVersion">
   <!-- Do your custom version update here -->
@@ -110,6 +110,14 @@ If you need to parse extra command line parameters to the `xcrun xcodebuild arch
 ```
   <AppClips Include="./Platforms/iOS/Native/Native.xcodeproj" XcodeParams="ENABLE_BITCODE=NO SKIP_INSTALL=NO"/>
 ```
+
+### Hint: Testing the Xcodebuild
+If you need to test and verify that the Xcode build part works, you can build these targets: `BuildAppClips`, `BuildWidgets`.
+This targets only the Xcode build step and avoids waiting for the entire MAUI project to build.
+```
+dotnet build -f:net9.0-ios -t:BuildAppClips,BuildWidgets MAUI.Native.Embedded.Sample/MAUI.Native.Embedded.Sample.csproj
+```
+
 
 ## TLDR;
 Support AppClip or Widget for iOS in your MAUI project by adding this to your project (.csproj) file:


### PR DESCRIPTION
Adding build targets for testing the xcode build parts without waiting for the entire MAUI project to build